### PR TITLE
Optionally allow converting the data to pseudo-obs on log-lik estimation

### DIFF
--- a/copulae/copula/abstract.py
+++ b/copulae/copula/abstract.py
@@ -55,7 +55,7 @@ class AbstractCopula(ABC):
         pass
 
     @abstractmethod
-    def log_lik(self, data: Array) -> float:
+    def log_lik(self, data: Array, *, to_pobs=True) -> float:
         pass
 
     @property

--- a/copulae/copula/base.py
+++ b/copulae/copula/base.py
@@ -193,7 +193,7 @@ class BaseCopula(AbstractCopula, ABC):
             Log Likelihood
 
         """
-        return self.pdf(self.pobs(data), log=True).sum()
+        return self.pdf(data, log=True).sum()
 
     @property
     @abstractmethod

--- a/copulae/copula/base.py
+++ b/copulae/copula/base.py
@@ -176,7 +176,7 @@ class BaseCopula(AbstractCopula, ABC):
         """
         raise NotImplementedError
 
-    def log_lik(self, data: np.ndarray) -> float:
+    def log_lik(self, data: np.ndarray, *, to_pobs=True) -> float:
         r"""
          Returns the log likelihood (LL) of the copula given the data.
 
@@ -186,6 +186,8 @@ class BaseCopula(AbstractCopula, ABC):
         ----------
         data: ndarray
             Data set used to calculate the log likelihood
+        to_pobs: bool
+            If True, converts the data input to pseudo observations.
 
         Returns
         -------
@@ -193,6 +195,8 @@ class BaseCopula(AbstractCopula, ABC):
             Log Likelihood
 
         """
+        data = self.pobs(data) if to_pobs else data
+
         return self.pdf(data, log=True).sum()
 
     @property

--- a/copulae/copula/est_max_likelihood.py
+++ b/copulae/copula/est_max_likelihood.py
@@ -100,7 +100,7 @@ class MaxLikelihoodEstimator:
         """
         try:
             self.copula.params = param
-            return -self.copula.log_lik(self.data)
+            return -self.copula.log_lik(self.data, to_pobs=False)
         except ValueError:  # error encountered when setting invalid parameters
             return np.inf
 

--- a/copulae/elliptical/abstract.py
+++ b/copulae/elliptical/abstract.py
@@ -33,14 +33,14 @@ class AbstractEllipticalCopula(BaseCopula, ABC):
     def itau(self, tau):
         return np.sin(np.asarray(tau) * np.pi / 2)
 
-    def log_lik(self, data: np.ndarray):
+    def log_lik(self, data: np.ndarray, *, to_pobs=True):
         if not is_psd(self.sigma):
             return -np.inf
 
         if hasattr(self, '_df') and self._df <= 0:  # t copula
             return -np.inf
 
-        return super().log_lik(data)
+        return super().log_lik(data, to_pobs=to_pobs)
 
     @property
     def rho(self):

--- a/copulae/indep/indep.py
+++ b/copulae/indep/indep.py
@@ -51,7 +51,7 @@ class IndepCopula(BaseCopula):
     def lambda_(self):
         return TailDep(0, 0)
 
-    def log_lik(self, data: np.ndarray):
+    def log_lik(self, data: np.ndarray, *, to_pobs=True):
         print('Log Likelihood not available for indepedence copula')
         return
 


### PR DESCRIPTION
Hi, 
You already call: `data = self.pobs(data)`

In the `fit()` method so the data is already ranked.

Re-ranking the data doesn't change anything but is computationally very slow. 

However I may have missed something.

Thanks,

Jacob