### PR TITLE
NumPy 2.0 Compatibility

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,5 +1,5 @@
 cython>=0.29
-numpy>=1.24
+numpy>=2.0
 pandas>=2.0
 pytest>=7
 pytest-cov>=2.10

--- a/copulae/archimedean/clayton.py
+++ b/copulae/archimedean/clayton.py
@@ -96,7 +96,10 @@ class ClaytonCopula(AbstractArchimedeanCopula):
 
     @params.setter
     def params(self, theta: float):
-        theta = float(theta)
+        if np.isscalar(theta):
+            theta = float(theta)
+        elif isinstance(theta, np.ndarray) and theta.size == 1:
+            theta = float(theta.item())
 
         if self.dim == 2 and theta < -1:
             raise ValueError('theta must be greater than -1 in 2 dimensional Clayton copula')

--- a/copulae/archimedean/frank.py
+++ b/copulae/archimedean/frank.py
@@ -123,7 +123,10 @@ class FrankCopula(AbstractArchimedeanCopula):
     def params(self, theta):
         if self.dim > 2 and theta < 0:
             raise ValueError('theta must be positive when dim > 2')
-        self._theta = float(theta)
+        if np.isscalar(theta):
+            self._theta = float(theta)
+        elif isinstance(theta, np.ndarray) and theta.size == 1:
+            self._theta = float(theta.item()) 
 
     @validate_data_dim({"u": [1, 2]})
     @shape_first_input_to_cop_dim

--- a/copulae/archimedean/frank.py
+++ b/copulae/archimedean/frank.py
@@ -237,7 +237,7 @@ def debye1(x):
     --------
     :code:`copulae.special.debye.debye_1`: The debye order 1 function
     """
-    x = np.asarray(x, np.float_).ravel()
+    x = np.asarray(x, np.float64).ravel()
     fin = np.isfinite(x)
     d = np.ravel(np.abs(x))
 
@@ -275,7 +275,7 @@ def debye2(x):
     --------
     :code:`copulae.special.debye.debye_2`: The debye order 2 function
     """
-    x = np.asarray(x, np.float_).ravel()
+    x = np.asarray(x, np.float64).ravel()
     fin = np.isfinite(x)
     d = np.ravel(np.abs(x))
 

--- a/copulae/archimedean/gumbel.py
+++ b/copulae/archimedean/gumbel.py
@@ -156,7 +156,10 @@ class GumbelCopula(AbstractArchimedeanCopula):
     def itau(self, tau):
         warning_message = "For the Gumbel copula, tau must be >= 0. Replacing negative values by 0."
         if np.size(tau) == 1:
-            tau = float(tau)
+            if np.isscalar(tau):
+                tau = float(tau)
+            elif isinstance(tau, np.ndarray) and tau.size == 1:
+                tau = float(tau.item())
             if tau < 0:
                 warnings.warn(warning_message)
                 return 1
@@ -175,7 +178,10 @@ class GumbelCopula(AbstractArchimedeanCopula):
 
     @params.setter
     def params(self, theta: float):
-        theta = float(theta)
+        if np.isscalar(theta):
+            theta = float(theta)
+        elif isinstance(theta, np.ndarray) and theta.size == 1:
+            theta = float(theta.item())
 
         if theta < 1:
             raise ValueError('<theta> must be >= 1 for Gumbel copula')

--- a/copulae/gof/_exchangeability.pyx
+++ b/copulae/gof/_exchangeability.pyx
@@ -209,7 +209,7 @@ def exch_test_stat(double[:, :] u, double[:, :] g, int n, int m):
     return s * n / m
 
 
-def exch_replication(long[:, :] ir, double[:, :] u, double[:, :] g, int n, int m, int ng):
+def exch_replication(int64_t[:, :] ir, double[:, :] u, double[:, :] g, int n, int m, int ng):
     """
     One instance of the bootstrap replication
 

--- a/copulae/gof/_radial_symmetry.pyx
+++ b/copulae/gof/_radial_symmetry.pyx
@@ -37,7 +37,7 @@ def rad_sym_test_stat(const double[:] u, const int n, const int p):
     return s
 
 
-def rad_sym_replicate(double[:, :] u, long[:, :] ir, const int n, const int p, bint has_ties):
+def rad_sym_replicate(double[:, :] u, int64_t[:, :] ir, const int n, const int p, bint has_ties):
     """One instance of bootstrap replication for radial symmetry test"""
     cdef:
         double[:, :] ub = np.copy(u), tub

--- a/copulae/utility/annotations/reshape.py
+++ b/copulae/utility/annotations/reshape.py
@@ -101,4 +101,8 @@ def shape_first_input_to_cop_dim(method, instance: BaseCopula, args, kwargs):
 def squeeze_output(method, _, args, kwargs) -> Union[np.ndarray, pd.Series, float]:
     """Squeezes the output to a float if the size is one"""
     output: Union[float, np.ndarray, pd.Series] = method(*args, **kwargs)
-    return float(output) if np.isscalar(output) or output.size == 1 else output
+    if np.isscalar(output):
+        return float(output)
+    elif isinstance(output, np.ndarray) and output.size == 1:
+        return float(output.item())
+    return output

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ requires = ["cython", "numpy", "scipy"]
 python_requires = >= 3.8
 include_package_data = true
 install_requires =
-    numpy >= 1.20
+    numpy >= 2.0
     pandas >= 1.1
     scikit-learn >= 0.23
     scipy >= 1.5


### PR DESCRIPTION
This PR addresses compatibility issues with NumPy 2.0 and resolves test failures caused by the upgrade when running locally with Copulae 0.7.9 (closes #67).

If there is anything else you need me to adjust for this PR to be helpful, please let me know.
